### PR TITLE
fixed typo on offset

### DIFF
--- a/src/basis/tilecoding.jl
+++ b/src/basis/tilecoding.jl
@@ -134,7 +134,7 @@ function (ϕ::TileCodingBasis{<:Vector{<:StepRangeLen}})(x)
         fwrap(i,x) = get_tiling(ϕ.bins, ϕ.lidxs, ϕ.num_inputs, x, offset(i), tile_index_wrap)
         return ntuple(i->fwrap(i,x), ϕ.num_tilings)
     else
-        freg(i,x) = get_tiling(ϕ.bins, ϕ.lidxs, ϕ.num_inputs, x, offsets(i), tile_index)
+        freg(i,x) = get_tiling(ϕ.bins, ϕ.lidxs, ϕ.num_inputs, x, offset(i), tile_index)
         return ntuple(i->freg(i,x), ϕ.num_tilings)
     end
 end

--- a/test/basistest.jl
+++ b/test/basistest.jl
@@ -149,6 +149,15 @@ using Test
     @test f([1.0, 1.0, 1.0]) == (1,1)
     @test f([0.99, 0.99, 0.99]) == (prod(tiles_per_dim),1)
 
+    num_tilings = 2
+    f = TileCodingBasis(tiles_per_dim, num_tilings=num_tilings, tiling_type=:clip)
+    @test typeof(f([0.0, 0.0, 0.0])) == Tuple{Int,Int}
+    @test length(f) == prod(tiles_per_dim) * num_tilings
+    @test size(f) == (prod(tiles_per_dim),num_tilings)
+    @test f([0.0, 0.0, 0.0]) == (1,1)
+    @test f([1.0, 1.0, 1.0]) == (prod(tiles_per_dim),prod(tiles_per_dim))
+    @test f([0.99, 0.99, 0.99]) == (prod(tiles_per_dim),prod(tiles_per_dim))
+
     num_tilings = 4
     f = TileCodingBasis(tiles_per_dim, num_tilings=num_tilings, tiling_type=tiling_type, tile_loc=:random)
     @test typeof(f([0.0, 0.0, 0.0])) == NTuple{num_tilings,Int}


### PR DESCRIPTION
Fixed typo causing an error when tile_per_dim array plus clipping was used to specify the tiling configuration. Added unit tests to check for this combo. 